### PR TITLE
Fix merging order after reconnect.

### DIFF
--- a/lib/live-collection.js
+++ b/lib/live-collection.js
@@ -152,7 +152,7 @@ module.exports = Backbone.Collection.extend({
       var forKeeping = this.where({ presnapshot: undefined });
 
       // add one by one
-      this.set(snapshot.concat(forKeeping), options);
+      this.set(forKeeping.concat(snapshot), options);
     } else {
       // trash it and add all in one go
       this.reset(snapshot, options);


### PR DESCRIPTION
When doing unlisten->listen cycle with new items appeared in between, they were misplaced because collections were merged in wrong order.
