### PR TITLE
New sort

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,5 +5,6 @@ module.exports = {
   RealtimeClient: require('./realtime-client'),
   RoomCollection: require('./room-collection'),
   RoomModel: require('./room-model'),
-  filteredRooms: require('./filtered-rooms')
+  filteredRooms: require('./filtered-rooms'),
+  sortsFilters: require('./sorts-filters')
 };

--- a/lib/room-model.js
+++ b/lib/room-model.js
@@ -21,27 +21,34 @@ module.exports = Backbone.Model.extend({
       var time = this.get('lastAccessTime');
 
       if (time) {
-        this.set('lastAccessTimeNoSync', time.clone());
+        this.set('lastAccessTimeOnLoad', time.clone());
+      } else if(this.get('unreadItems')) {
+        // room has been added to the list but the user has never visited it.
+        // probably a fresh mention in a room.
+        // better escalate this room to be highest on the list.
+        this.set('escalationTime', moment());
       }
 
       if(this.get('unreadItems')) {
-        this.set('hasHadUnreadItemsAtSomePoint', true);
+        this.set('hadUnreadItemsOnLoad', true);
       }
 
       if(this.get('mentions')) {
-        this.set('hasHadMentionsAtSomePoint', true);
+        this.set('hadMentionsOnLoad', true);
       }
     }
 
-    this.listenTo(this, 'change:unreadItems', function (model, unreadItems) { // jshint unused:true
-      if(unreadItems) {
-        this.set('hasHadUnreadItemsAtSomePoint', true);
+    this.listenTo(this, 'change:mentions', function (model, mentions) { // jshint unused:true
+      if(!this.previous('mentions') && mentions) {
+        // changed from 0 mentions to 1+, so escalate this room to be highest on the list
+        this.set('escalationTime', moment());
       }
     });
 
-    this.listenTo(this, 'change:mentions', function(model, mentions) { // jshint unused:true
-      if(mentions) {
-        this.set('hasHadMentionsAtSomePoint', true);
+    this.listenTo(this, 'change:unreadItems', function (model, unreadItems) { // jshint unused:true
+      if(!this.previous('unreadItems') && unreadItems) {
+        // changed from 0 unread to 1+, so escalate this room to be highest on the list
+        this.set('escalationTime', moment());
       }
     });
 

--- a/lib/sorts-filters.js
+++ b/lib/sorts-filters.js
@@ -47,9 +47,9 @@ function timeDifference(a, b) {
   // lastAccessTimeNoSync is used to ensure that rooms dont jump around when
   // lastAccessTime is updated after a user visits a room
   // lastAccessTimeNoSync is not available on the server, so we have a failover.
-  // valueOf converts moments, dates and unixtime ints to unixtime ints.
-  var aTime = (a.lastAccessTimeOnLoad || a.lastAccessTime || 0).valueOf();
-  var bTime = (b.lastAccessTimeOnLoad || b.lastAccessTime || 0).valueOf();
+  // new Date(x).valueOf converts Moments, Dates, Strings and unixtime ints to unixtime ints.
+  var aTime = new Date(a.lastAccessTimeOnLoad || a.lastAccessTime || 0).valueOf();
+  var bTime = new Date(b.lastAccessTimeOnLoad || b.lastAccessTime || 0).valueOf();
 
   return bTime - aTime;
 }

--- a/lib/sorts-filters.js
+++ b/lib/sorts-filters.js
@@ -34,9 +34,9 @@ function getRank(room) {
   // to ensure that rooms dont jump around when mentions is updated after a
   // user visits a room and reads all the mentions.
   // hasHadMentionsAtSomePoint is not available on the server, so we have a failover.
-  if (room.hasHadMentionsAtSomePoint || room.mentions) {
+  if (room.hadMentionsOnLoad || room.mentions) {
     return 0;
-  } else if (room.hasHadUnreadItemsAtSomePoint || room.unreadItems) {
+  } else if (room.hadUnreadItemsOnLoad || room.unreadItems) {
     return 1;
   } else {
     return 2;
@@ -47,20 +47,19 @@ function timeDifference(a, b) {
   // lastAccessTimeNoSync is used to ensure that rooms dont jump around when
   // lastAccessTime is updated after a user visits a room
   // lastAccessTimeNoSync is not available on the server, so we have a failover.
-  var aDate = a.lastAccessTimeNoSync || a.lastAccessTime;
-  var bDate = b.lastAccessTimeNoSync || b.lastAccessTime;
+  // valueOf converts moments, dates and unixtime ints to unixtime ints.
+  var aTime = (a.lastAccessTimeOnLoad || a.lastAccessTime || 0).valueOf();
+  var bTime = (b.lastAccessTimeOnLoad || b.lastAccessTime || 0).valueOf();
 
-  if(!aDate && !bDate) {
-    return 0;
-  } else if(!aDate) {
-    // therefore bDate exists and is best
-    return 1;
-  } else if(!bDate) {
-    // therefore aDate exists and is best
-    return -1;
-  } else {
-    return new Date(bDate).valueOf() - new Date(aDate).valueOf();
-  }
+  return bTime - aTime;
+}
+
+function escalationDifference(a, b) {
+  var aTime = a.escalationTime && a.escalationTime.valueOf() || 0;
+  var bTime = b.escalationTime && b.escalationTime.valueOf() || 0;
+
+  // most recently escalated is better
+  return bTime - aTime;
 }
 
 var favouritesSort = nullsLast(function(a, b) {
@@ -77,14 +76,18 @@ var favouritesFilter = filterNulls(function(room) {
 });
 
 var recentsSort = nullsLast(function(a, b) {
-  var aRank = getRank(a);
-  var bRank = getRank(b);
+    var escDiff = escalationDifference(a, b);
 
-  if (aRank === bRank) {
-    return timeDifference(a, b, aRank);
-  } else {
-    return aRank - bRank;
-  }
+    if (escDiff) return escDiff;
+
+    var aRank = getRank(a);
+    var bRank = getRank(b);
+
+    if (aRank === bRank) {
+      return timeDifference(a, b);
+    } else {
+      return aRank - bRank;
+    }
 });
 
 var recentsFilter = filterNulls(function(room) {

--- a/test/sorts-filters.js
+++ b/test/sorts-filters.js
@@ -97,19 +97,19 @@ describe('room-sort', function() {
             id: 'room',
             unreadItems: 5,
             mentions: 3,
-            hasHadUnreadItemsAtSomePoint: true,
-            hasHadMentionsAtSomePoint: true,
+            hadUnreadItemsOnLoad: true,
+            hadMentionsOnLoad: true,
             lastAccessTime: OLD,
-            lastAccessTimeNoSync: OLD
+            lastAccessTimeOnLoad: OLD
           });
           var roomToUpdate = new Backbone.Model({
             id: 'room_to_update',
             unreadItems: 3,
             mentions: 1,
-            hasHadUnreadItemsAtSomePoint: true,
-            hasHadMentionsAtSomePoint: true,
+            hadUnreadItemsOnLoad: true,
+            hadMentionsOnLoad: true,
             lastAccessTime: VERY_OLD,
-            lastAccessTimeNoSync: VERY_OLD
+            lastAccessTimeOnLoad: VERY_OLD
           });
           var collection = new RecentsCollection([room, roomToUpdate]);
 
@@ -128,28 +128,28 @@ describe('room-sort', function() {
             id: 'room',
             unreadItems: 1,
             mentions: 1,
-            hasHadUnreadItemsAtSomePoint: true,
-            hasHadMentionsAtSomePoint: true,
+            hadUnreadItemsOnLoad: true,
+            hadMentionsOnLoad: true,
             lastAccessTime: OLD,
-            lastAccessTimeNoSync: OLD
+            lastAccessTimeOnLoad: OLD
           });
           var roomToUpdate = new Backbone.Model({
             id: 'room_to_update',
             unreadItems: 1,
             mentions: 1,
-            hasHadUnreadItemsAtSomePoint: true,
-            hasHadMentionsAtSomePoint: true,
+            hadUnreadItemsOnLoad: true,
+            hadMentionsOnLoad: true,
             lastAccessTime: VERY_OLD,
-            lastAccessTimeNoSync: VERY_OLD
+            lastAccessTimeOnLoad: VERY_OLD
           });
           var veryVeryOldRoom = new Backbone.Model({
             id: 'very_very_old_room',
             unreadItems: 1,
             mentions: 1,
-            hasHadUnreadItemsAtSomePoint: true,
-            hasHadMentionsAtSomePoint: true,
+            hadUnreadItemsOnLoad: true,
+            hadMentionsOnLoad: true,
             lastAccessTime: VERY_VERY_OLD,
-            lastAccessTimeNoSync: VERY_VERY_OLD
+            lastAccessTimeOnLoad: VERY_VERY_OLD
           });
           var collection = new RecentsCollection([room, roomToUpdate, veryVeryOldRoom]);
 
@@ -178,6 +178,18 @@ describe('room-sort', function() {
           assert.deepEqual(id(collection), ['unread', 'regular']);
         });
 
+        it('puts new unreads above rooms that had unreads (issue troupe/gitter-webapp#368)', function() {
+          var collection = new RecentsCollection([
+            { id: 'regular' },
+            { id: 'was_unread', hadUnreadItemsOnLoad: true, lastAccessTime: OLD },
+            { id: 'unread', unreadItems: 1, escalationTime: NEW }
+          ]);
+
+          collection.sort();
+
+          assert.deepEqual(id(collection), ['unread', 'was_unread', 'regular']);
+        });
+
         it('sorts multiple unread rooms by time of last access', function() {
           var collection = new RecentsCollection([
             { id: 'old_unread', unreadItems: 5, lastAccessTime: OLD },
@@ -204,16 +216,16 @@ describe('room-sort', function() {
           var room = new Backbone.Model({
             id: 'room',
             unreadItems: 5,
-            hasHadUnreadItemsAtSomePoint: true,
+            hadUnreadItemsOnLoad: true,
             lastAccessTime: OLD,
-            lastAccessTimeNoSync: OLD
+            lastAccessTimeOnLoad: OLD
           });
           var roomToUpdate = new Backbone.Model({
             id: 'room_to_update',
             unreadItems: 3,
-            hasHadUnreadItemsAtSomePoint: true,
+            hadUnreadItemsOnLoad: true,
             lastAccessTime: VERY_OLD,
-            lastAccessTimeNoSync: VERY_OLD
+            lastAccessTimeOnLoad: VERY_OLD
           });
           var collection = new RecentsCollection([room, roomToUpdate]);
 
@@ -231,23 +243,23 @@ describe('room-sort', function() {
           var room = new Backbone.Model({
             id: 'room',
             unreadItems: 1,
-            hasHadUnreadItemsAtSomePoint: true,
+            hadUnreadItemsOnLoad: true,
             lastAccessTime: OLD,
-            lastAccessTimeNoSync: OLD
+            lastAccessTimeOnLoad: OLD
           });
           var roomToUpdate = new Backbone.Model({
             id: 'room_to_update',
             unreadItems: 1,
-            hasHadUnreadItemsAtSomePoint: true,
+            hadUnreadItemsOnLoad: true,
             lastAccessTime: VERY_OLD,
-            lastAccessTimeNoSync: VERY_OLD
+            lastAccessTimeOnLoad: VERY_OLD
           });
           var veryVeryOldRoom = new Backbone.Model({
             id: 'very_very_old_room',
             unreadItems: 1,
-            hasHadUnreadItemsAtSomePoint: true,
+            hadUnreadItemsOnLoad: true,
             lastAccessTime: VERY_VERY_OLD,
-            lastAccessTimeNoSync: VERY_VERY_OLD
+            lastAccessTimeOnLoad: VERY_VERY_OLD
           });
           var collection = new RecentsCollection([room, roomToUpdate, veryVeryOldRoom]);
 
@@ -289,8 +301,8 @@ describe('room-sort', function() {
         });
 
         it('doesnt move rooms if they are later accessed', function() {
-          var room = new Backbone.Model({ id: 'room', lastAccessTime: OLD, lastAccessTimeNoSync: OLD });
-          var roomToUpdate = new Backbone.Model({ id: 'room_to_update', lastAccessTime: VERY_OLD, lastAccessTimeNoSync: VERY_OLD });
+          var room = new Backbone.Model({ id: 'room', lastAccessTime: OLD, lastAccessTimeOnLoad: OLD });
+          var roomToUpdate = new Backbone.Model({ id: 'room_to_update', lastAccessTime: VERY_OLD, lastAccessTimeOnLoad: VERY_OLD });
           var collection = new RecentsCollection([room, roomToUpdate]);
 
           collection.sort();


### PR DESCRIPTION
Sorts by an `escalationTime` instead. Escalation time is set whenever something important happens (new unread mentions when there was previously none, new mentions when there was previously none etc). The newer the escalation time, the higher the room appears on the list.

As this `escalationTime` isnt set on the server, we still have the fallback to the old style sort if there is no difference between `escaltionTime`'s.

This also exposes the sort module.
