### PR TITLE
Left menu filtering

### DIFF
--- a/lib/sorts-filters.js
+++ b/lib/sorts-filters.js
@@ -94,6 +94,10 @@ var recentsFilter = filterNulls(function(room) {
   return !room.favourite && !!(room.lastAccessTime || room.unreadItems || room.mentions);
 });
 
+var recentsLeftMenuFilter = filterNulls(function(room) {
+  return !!(room.lastAccessTime || room.unreadItems || room.mentions);
+});
+
 var unreadsSort = nullsLast(function (model) {
   return model.lastAccessTime;
 });
@@ -117,6 +121,10 @@ module.exports = {
     unreads: {
       sort: unreadsSort,
       filter: unreadsFilter
+    },
+    leftMenu: {
+      sort: nullsLast(recentsSort),
+      filter: recentsLeftMenuFilter
     }
   },
   model: {
@@ -131,6 +139,10 @@ module.exports = {
     unreads: {
       sort: modelAdapter(unreadsSort),
       filter: modelAdapter(unreadsFilter)
+    },
+    leftMenu: {
+      sort: modelAdapter(recentsSort),
+      filter: modelAdapter(recentsLeftMenuFilter)
     }
   }
 };

--- a/test/sorts-filters.js
+++ b/test/sorts-filters.js
@@ -335,7 +335,7 @@ describe('room-sort', function() {
   });
 
   describe.only('left-menu', function(){
-    it('filters out favourites', function() {
+    it('does not filter out favourites', function() {
       var collection = new Backbone.Collection([
         { id: 1, favourite: 1, unreadItems: 1 },
         { id: 2, unreadItems: 1 }

--- a/test/sorts-filters.js
+++ b/test/sorts-filters.js
@@ -334,7 +334,7 @@ describe('room-sort', function() {
 
   });
 
-  describe.only('left-menu', function(){
+  describe('left-menu', function(){
     it('does not filter out favourites', function() {
       var collection = new Backbone.Collection([
         { id: 1, favourite: 1, unreadItems: 1 },

--- a/test/sorts-filters.js
+++ b/test/sorts-filters.js
@@ -334,6 +334,20 @@ describe('room-sort', function() {
 
   });
 
+  describe.only('left-menu', function(){
+    it('filters out favourites', function() {
+      var collection = new Backbone.Collection([
+        { id: 1, favourite: 1, unreadItems: 1 },
+        { id: 2, unreadItems: 1 }
+      ]);
+
+      var filteredCollection = collection.filter(roomSort.model.leftMenu.filter);
+
+      assert.deepEqual(id(filteredCollection), [1, 2]);
+    });
+
+  });
+
 });
 
 function id(collection) {


### PR DESCRIPTION
The current `recents` filter removes favourites. Whilst this was sensible for the old left menu it is unpractical in the new menu. This PR adds a `leftMenu` object for filters.

NB: This should be removed when the feature toggle is removed.
