### PR TITLE
Only set loading on read requests

### DIFF
--- a/lib/backbone-state-tracking.js
+++ b/lib/backbone-state-tracking.js
@@ -4,22 +4,24 @@
 var LOADING_EVENTS = 'request';
 var LOADED_EVENTS = 'sync error reset';
 
-function loadingChange(obj, newState) {
-  newState = !!newState;
-  var current = !!obj.loading;
-  obj.loading = newState;
-  if (newState !== current) {
-    obj.trigger(newState ? "loading" : "loaded", obj);
-    obj.trigger('loading:change', obj, newState);
+function loadingChange(obj, newState, options) {
+  if(!options || (options && options.method === 'read')) {
+    newState = !!newState;
+    var current = !!obj.loading;
+    obj.loading = newState;
+    if (newState !== current) {
+      obj.trigger(newState ? "loading" : "loaded", obj);
+      obj.trigger('loading:change', obj, newState);
+    }
   }
 }
 
-function onLoading() {
-  loadingChange(this, true);
+function onLoading(model, xhr, options) {
+  loadingChange(this, true, options);
 }
 
-function onLoaded() {
-  loadingChange(this, false);
+function onLoaded(model, xhr, options) {
+  loadingChange(this, false, options);
 }
 
 module.exports = {

--- a/lib/backbone-state-tracking.js
+++ b/lib/backbone-state-tracking.js
@@ -5,14 +5,17 @@ var LOADING_EVENTS = 'request';
 var LOADED_EVENTS = 'sync error reset';
 
 function loadingChange(obj, newState, options) {
-  if(!options || (options && options.method === 'read')) {
-    newState = !!newState;
-    var current = !!obj.loading;
-    obj.loading = newState;
-    if (newState !== current) {
-      obj.trigger(newState ? "loading" : "loaded", obj);
-      obj.trigger('loading:change', obj, newState);
-    }
+  newState = !!newState;
+  var current = !!obj.loading;
+
+  if(options && options.method !== 'read') {
+    newState = false;
+  }
+
+  obj.loading = newState;
+  if (newState !== current) {
+    obj.trigger(newState ? "loading" : "loaded", obj);
+    obj.trigger('loading:change', obj, newState);
   }
 }
 


### PR DESCRIPTION
Only set `loading` on read requests.

This helps with the `loading` false positives when creating new things. `collection.create({});`

This is part of the fix for https://github.com/gitterHQ/gitter/issues/1034 which can be followed here https://github.com/troupe/gitter-webapp/pull/2111
